### PR TITLE
Update pytest dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.6.0
 Flask==0.12.2
 requests==2.9.1
-pytest==3.0.7
+pytest==3.6
 newspaper3k==0.1.9


### PR DESCRIPTION
The pytest dependency used by the reader is old and conflicts
with the dependency required by the Teacher-Dashboard.

Teacher-Dashboard requires minimum pytest version 3.6.

This commit updates the pytest requirement for reader to 3.6.